### PR TITLE
Compatibilidad python 3.10

### DIFF
--- a/attrdict/default.py
+++ b/attrdict/default.py
@@ -1,7 +1,7 @@
 """
 A subclass of MutableAttr that has defaultdict support.
 """
-from collections import Mapping
+from collections.abc import Mapping
 
 import six
 

--- a/attrdict/mapping.py
+++ b/attrdict/mapping.py
@@ -1,7 +1,7 @@
 """
 An implementation of MutableAttr.
 """
-from collections import Mapping
+from collections.abc import Mapping
 
 import six
 

--- a/attrdict/merge.py
+++ b/attrdict/merge.py
@@ -1,7 +1,7 @@
 """
 A right-favoring Mapping merge.
 """
-from collections import Mapping
+from collections.abc import Mapping
 
 
 __all__ = ['merge']

--- a/attrdict/mixins.py
+++ b/attrdict/mixins.py
@@ -2,7 +2,7 @@
 Mixin Classes for Attr-support.
 """
 from abc import ABCMeta, abstractmethod
-from collections import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 import re
 
 import six

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except:
 
 setup(
     name="attrdict",
-    version="2.0.1",
+    version="3.0.1",
     author="Brendan Curran-Johnson",
     author_email="brendan@bcjbcj.ca",
     packages=("attrdict",),


### PR DESCRIPTION
Modificados los _imports_ para que utilicen el módulo `abc `de la clase `collections`